### PR TITLE
Specific permit attributes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'aws-sdk-s3', '~>1', require: false
 
 gem 'rails_admin', '~> 2.0'
 
+gem 'acts-as-taggable-on', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
@@ -168,8 +170,6 @@ GEM
     rack-pjax (1.1.0)
       nokogiri (~> 1.5)
       rack (>= 1.1)
-    rack-proxy (0.6.5)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.1)
@@ -267,7 +267,6 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    semantic_range (2.3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -296,11 +295,6 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webpacker (5.1.1)
-      activesupport (>= 5.2)
-      rack-proxy (>= 0.6.1)
-      railties (>= 5.2)
-      semantic_range (>= 2.3.0)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -312,6 +306,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   aws-sdk-s3 (~> 1)
   bootsnap (>= 1.4.2)
   byebug
@@ -334,7 +329,6 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers
-  webpacker (~> 5.x)
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -39,7 +39,7 @@
 
 	.Table-row, .Table-header {
 		display: grid;
-		grid-template-columns: repeat(6, 1fr);
+		grid-template-columns: repeat(9, 1fr);
 	}
 
 	.Table-cell {

--- a/app/controllers/permit_submissions_controller.rb
+++ b/app/controllers/permit_submissions_controller.rb
@@ -59,7 +59,7 @@ class PermitSubmissionsController < ApplicationController
   end
 
   def permit_params
-    params.require(:permit_submission).permit(:name, :user_id, :agency, :deadline, :status, :permittee, :location, :equipment, :permit_type_id, permit_documents_attributes: [:document, :_destroy, :id])
+    params.require(:permit_submission).permit(:name, :user_id, :agency, :deadline, :status, :permittee, :location, :equipment, :permit_type_id, :tag_list, permit_documents_attributes: [:document, :_destroy, :id])
   end
 
   def permit_document_params

--- a/app/controllers/permit_submissions_controller.rb
+++ b/app/controllers/permit_submissions_controller.rb
@@ -16,7 +16,7 @@ class PermitSubmissionsController < ApplicationController
   end
 
   def show
-    @permit = current_user.permit_submissions.find(params.fetch(:id))
+    @permit = PermitSubmission.find(params.fetch(:id))
   end
 
   def create
@@ -59,7 +59,7 @@ class PermitSubmissionsController < ApplicationController
   end
 
   def permit_params
-    params.require(:permit_submission).permit(:name, :agency, :deadline, :status, :permittee, :location, :equipment, :permit_type_id, permit_documents_attributes: [:document, :_destroy, :id]).merge(user_id: current_user.id)
+    params.require(:permit_submission).permit(:name, :user_id, :agency, :deadline, :status, :permittee, :location, :equipment, :permit_type_id, permit_documents_attributes: [:document, :_destroy, :id])
   end
 
   def permit_document_params

--- a/app/controllers/permit_submissions_controller.rb
+++ b/app/controllers/permit_submissions_controller.rb
@@ -59,7 +59,7 @@ class PermitSubmissionsController < ApplicationController
   end
 
   def permit_params
-    params.require(:permit_submission).permit(:name, :agency, :deadline, :status, :permit_type_id, permit_documents_attributes: [:document, :_destroy, :id]).merge(user_id: current_user.id)
+    params.require(:permit_submission).permit(:name, :agency, :deadline, :status, :permittee, :location, :equipment, :permit_type_id, permit_documents_attributes: [:document, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
   def permit_document_params

--- a/app/models/permit_submission.rb
+++ b/app/models/permit_submission.rb
@@ -3,6 +3,8 @@ class PermitSubmission < ApplicationRecord
 
   enum status: {closed: "closed", ineffect: "in-effect", application: "application"}
 
+  acts_as_taggable_on :tags
+
   belongs_to :user
   belongs_to :permit_type
 

--- a/app/models/permit_submission.rb
+++ b/app/models/permit_submission.rb
@@ -1,8 +1,8 @@
 class PermitSubmission < ApplicationRecord
   include PgSearch::Model
 
-  enum status: %i[accepted filed denied]
-  
+  enum status: {closed: "closed", ineffect: "in-effect", application: "application"}
+
   belongs_to :user
   belongs_to :permit_type
 

--- a/app/models/permit_submission.rb
+++ b/app/models/permit_submission.rb
@@ -1,7 +1,8 @@
 class PermitSubmission < ApplicationRecord
   include PgSearch::Model
 
-  # enum status: %i[accepted filed denied]
+  enum status: %i[accepted filed denied]
+  
   belongs_to :user
   belongs_to :permit_type
 

--- a/app/models/permit_submission.rb
+++ b/app/models/permit_submission.rb
@@ -18,6 +18,8 @@ class PermitSubmission < ApplicationRecord
   attribute :deadline, :datetime
   attribute :agency, :string
 
+  validates :user_id, :presence => true
+
   pg_search_scope :search_permits,
                   against: %i[name agency],
                   associated_against: {

--- a/app/views/permit_submissions/edit.html.erb
+++ b/app/views/permit_submissions/edit.html.erb
@@ -55,6 +55,19 @@
       <%= f.text_field :location %>
     </div>
   </div>
+	<% if current_user.manager? %>
+		<div class="flex mb-2 -mx-2">
+	    <%= f.label "Assigned User", class: "w-1/4 px-2" %>
+	  </div>
+		<div class="flex mb-4 -mx-2">
+	    <div class = "w-1/4 px-2">
+	      <%= f.select :user_id, User.all.collect{|u| ["#{u.first_name} #{u.last_name}", u.id]} %>
+	    </div>
+	  </div>
+	<% else %>
+		<%= f.hidden_field :user_id, value: current_user.id %>
+		<%= hidden_field_tag 'selected', 'none'  %>
+	<% end %>
   <div class = "flex mb-4">
     <%= f.fields_for :permit_documents do |document_form| %>
       <div class="max-w-xs rounded overflow-hidden shadow-lg bg-gray-300 mt-2 p-2">

--- a/app/views/permit_submissions/edit.html.erb
+++ b/app/views/permit_submissions/edit.html.erb
@@ -32,7 +32,7 @@
       <%= f.text_field :agency %>
     </div>
     <div class = "w-1/4 px-2">
-      <%= f.select :status, options_for_select(PermitSubmission.statuses.map{|k,v| [k.humanize, k]}), id: :status %>
+      <%= f.select :status, options_for_select(PermitSubmission.statuses.map{|k,v| [v.humanize, k]}) %>
     </div>
   </div>
   <div class="flex mb-2 -mx-2">

--- a/app/views/permit_submissions/edit.html.erb
+++ b/app/views/permit_submissions/edit.html.erb
@@ -1,57 +1,80 @@
-<div class="table">
-  <div class="flex-row">
-    <div class="flex-col">
-      <h1>Edit Permit</h1>
-      <div class="inline-block">
-        <%= link_to 'Delete', '#modal', class: "delete-button mt-2 mb-2" %>
+<h1>Edit Permit</h1>
+<div id="modal" class="overlay">
+	<div class="popup">
+		<h2>Delete Permit</h2>
+		<a class="close" href="#">&times;</a>
+		<div class="content">
+      <div class="flex mb-1"
+			   <p>Are you sure you'd like to delete this permit?</p>
+      </div>
+      <div class="flex mb-1"
+        <%= button_to 'Yes', {controller: :permit_submissions, :action => 'destroy', :permit_id => @permit.id }, {method: :delete, class: "delete-button"} %>
+        <%= link_to 'No', '#', class: "blue-button text-xs font-sans ml-1" %>
+      </div>
+		</div>
+	</div>
+</div>
+<%= form_with model: @permit do |f| %>
+  <div class="flex mb-2 -mx-2">
+    <%= f.label "Name", class: "w-1/4 px-2 " %>
+    <%= f.label "Type", class: "w-1/4 px-2" %>
+    <%= f.label "Agency", class: "w-1/4 px-2" %>
+    <%= f.label "Status", class: "w-1/4 px-2" %>
+  </div>
+  <div class="flex mb-4 -mx-2">
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :name %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.select :permit_type_id, PermitType.all.collect{|t| [t.name, t.id]} %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :agency %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.select :status, options_for_select(PermitSubmission.statuses.map{|k,v| [k.humanize, k]}), id: :status %>
+    </div>
+  </div>
+  <div class="flex mb-2 -mx-2">
+    <%= f.label "Deadline", class: "w-1/4 px-2" %>
+    <%= f.label "Permittee", class: "w-1/4 px-2" %>
+    <%= f.label "Equipment", class: "w-1/4 px-2" %>
+    <%= f.label "Location", class: "w-1/4 px-2" %>
+  </div>
+  <div class="flex mb-4 -mx-2">
+    <div class = "w-1/4 px-2">
+      <%= f.date_field :deadline %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :permittee %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :equipment %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :location %>
+    </div>
+  </div>
+  <div class = "flex mb-4">
+    <%= f.fields_for :permit_documents do |document_form| %>
+      <div class="max-w-xs rounded overflow-hidden shadow-lg bg-gray-300 mt-2 p-2">
+        <% if document_form.object.document.attached? %>
+          <p class = "font-sans"> Name:<%= document_form.object.document.blob.filename %> </p>
+          <p class = "font-sans"> Format: <%= document_form.object.document.blob.content_type %> </p>
+          <p class = "font-sans"> Delete: <%= document_form.check_box :_destroy %> </p>
+          <% if document_form.object.document.previewable? %>
+            <%= image_tag(document_form.object.document.preview(resize: "200x200>")) %>
+          <% end %>
+        <% else %>
+          <%= document_form.file_field :document %>
+        <% end %>
       </div>
     </div>
-  </div>
-  <div id="modal" class="overlay">
-  	<div class="popup">
-  		<h2>Delete Permit</h2>
-  		<a class="close" href="#">&times;</a>
-  		<div class="content">
-        <div class="flex mb-1"
-  			   <p>Are you sure you'd like to delete this permit?</p>
-        </div>
-        <div class="flex mb-1"
-          <%= button_to 'Yes', {controller: :permit_submissions, :action => 'destroy', :permit_id => @permit.id }, {method: :delete, class: "delete-button"} %>
-          <%= link_to 'No', '#', class: "blue-button text-xs font-sans ml-1" %>
-        </div>
-  		</div>
-  	</div>
-  </div>
-  <div class="flex-row">
-    <div class="grid grid-cols-4">
-      <%= form_with model: @permit do |f| %>
-        <%= f.label "Name" %>
-        <%= f.text_field :name %>
-        <%= f.label "Agency" %>
-        <%= f.text_field :agency %>
-        <%= f.label "Status" %>
-        <%= f.select :status, [["accepted", "accepted"], ["denied", "denied"], ["filed", "filed"]] %>
-        <%= f.label "Deadline" %>
-        <%= f.date_field :deadline %>
-        <br>
-        Documents:
-        <%= f.fields_for :permit_documents do |document_form| %>
-          <div class="max-w-xs rounded overflow-hidden shadow-lg bg-gray-300 mt-2 p-2">
-            <% if document_form.object.document.attached? %>
-              <p class = "font-sans"> Name:<%= document_form.object.document.blob.filename %> </p>
-              <p class = "font-sans"> Format: <%= document_form.object.document.blob.content_type %> </p>
-              <p class = "font-sans"> Delete: <%= document_form.check_box :_destroy %> </p>
-              <% if document_form.object.document.previewable? %>
-                <%= image_tag(document_form.object.document.preview(resize: "200x200>")) %>
-              <% end %>
-            <% else %>
-              <%= document_form.file_field :document %>
-            <% end %>
-          </div>
-        <% end %>
-        <br>
-        <%= f.submit 'Update', class: "mt-2" %>
-      <% end %>
+    <% end %>
+  <div class = "flex">
+    <div class="w-full pr-2">
+      <%= f.submit 'Update'%>
+			<%= link_to 'Delete', '#modal', class: "delete-button ml-2" %>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/permit_submissions/edit.html.erb
+++ b/app/views/permit_submissions/edit.html.erb
@@ -55,6 +55,14 @@
       <%= f.text_field :location %>
     </div>
   </div>
+	<div class="flex mb-2 -mx-2">
+    <%= f.label "Tags", class: "w-1/4 px-2" %>
+	</div>
+	<div class="flex mb-4 -mx-2">
+    <div class = "w-1/4 px-2">
+			<%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>
+    </div>
+	</div>
 	<% if current_user.manager? %>
 		<div class="flex mb-2 -mx-2">
 	    <%= f.label "Assigned User", class: "w-1/4 px-2" %>

--- a/app/views/permit_submissions/edit.html.erb
+++ b/app/views/permit_submissions/edit.html.erb
@@ -69,7 +69,7 @@
 	  </div>
 		<div class="flex mb-4 -mx-2">
 	    <div class = "w-1/4 px-2">
-	      <%= f.select :user_id, User.all.collect{|u| ["#{u.first_name} #{u.last_name}", u.id]} %>
+	      <%= f.select :user_id, current_user.team.users.collect{|u| ["#{u.first_name} #{u.last_name}", u.id]} %>
 	    </div>
 	  </div>
 	<% else %>

--- a/app/views/permit_submissions/index.html.erb
+++ b/app/views/permit_submissions/index.html.erb
@@ -15,13 +15,16 @@
     <div class="Table-cell"><%= link_to "Agency", permits_path(sort_by: 'agency') %></div>
     <div class="Table-cell"><%= link_to "Permit", permits_path(sort_by: 'agency') %></div>
     <div class="Table-cell"><%= link_to "Deadline", permits_path(sort_by: 'deadline') %></div>
+    <div class="Table-cell"><%= link_to "Status", permits_path(sort_by: 'deadline') %></div>
+    <div class="Table-cell"><%= link_to "Permittee", permits_path(sort_by: 'deadline') %></div>
+    <div class="Table-cell"><%= link_to "Equipment", permits_path(sort_by: 'deadline') %></div>
+    <div class="Table-cell"><%= link_to "Location", permits_path(sort_by: 'deadline') %></div>
     <div class="Table-cell"></div>
   </div>
   <div class="Table-body">
     <% @permits.map do |permit| %>
       <div class="Table-row">
           <%= render 'shared/permit_row', permit: permit %>
-          <div class="Table-cell"><%= link_to 'Show documents', permit_submission_path(id: permit.id) %></div>
           <div class="Table-cell"><%= link_to "Edit permit", permit_edit_url(id: permit.id) %></div>
       </div>
     <% end %>

--- a/app/views/permit_submissions/new.html.erb
+++ b/app/views/permit_submissions/new.html.erb
@@ -18,7 +18,7 @@
       <%= f.text_field :agency %>
     </div>
     <div class = "w-1/4 px-2">
-      <%= f.select :status, options_for_select(PermitSubmission.statuses.map {|s, v| [s, s] }) %>
+      <%= f.select :status, options_for_select(PermitSubmission.statuses.map{|k,v| [v.humanize, k]}) %>
     </div>
   </div>
   <div class="flex mb-2 -mx-2">

--- a/app/views/permit_submissions/new.html.erb
+++ b/app/views/permit_submissions/new.html.erb
@@ -55,7 +55,7 @@
 	  </div>
 		<div class="flex mb-4 -mx-2">
 	    <div class = "w-1/4 px-2">
-	      <%= f.select :user_id, User.all.collect{|u| ["#{u.first_name} #{u.last_name}", u.id]} %>
+	      <%= f.select :user_id, current_user.team.users.collect{|u| ["#{u.first_name} #{u.last_name}", u.id]} %>
 	    </div>
 	  </div>
 	<% else %>

--- a/app/views/permit_submissions/new.html.erb
+++ b/app/views/permit_submissions/new.html.erb
@@ -40,6 +40,14 @@
     <div class = "w-1/4 px-2">
       <%= f.text_field :location %>
     </div>
+    <div class="flex mb-2 -mx-2">
+      <%= f.label "Tags", class: "w-1/4 px-2" %>
+  	</div>
+  	<div class="flex mb-4 -mx-2">
+      <div class = "w-1/4 px-2">
+  			<%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>
+      </div>
+  	</div>
   </div>
   <% if current_user.manager? %>
 		<div class="flex mb-2 -mx-2">

--- a/app/views/permit_submissions/new.html.erb
+++ b/app/views/permit_submissions/new.html.erb
@@ -1,20 +1,51 @@
 <h1>New Permit</h1>
 
 <%= form_with model: @permit, method: "post" do |f| %>
-  <%= f.label "Name" %>
-  <%= f.text_field :name %>
-  <%= f.label "Type" %>
-  <%= f.select :permit_type_id, PermitType.all.collect{|t| [t.name, t.id]} %>
-  <%= f.label "Agency" %>
-  <%= f.text_field :agency %>
-  <%= f.label "Status" %>
-  <%= f.select :status, [["accepted", "accepted"], ["denied", "denied"], ["filed", "filed"]] %>
-  <%= f.label "Deadline" %>
-  <%= f.date_field :deadline %>
-  <%= f.fields_for :permit_documents do |document_form| %>
-      <%= document_form.label :document %>
-      <%= document_form.file_field :document %>
-  <% end %>
-
+  <div class="flex mb-2 -mx-2">
+    <%= f.label "Name", class: "w-1/4 px-2 " %>
+    <%= f.label "Type", class: "w-1/4 px-2" %>
+    <%= f.label "Agency", class: "w-1/4 px-2" %>
+    <%= f.label "Status", class: "w-1/4 px-2" %>
+  </div>
+  <div class="flex mb-4 -mx-2">
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :name %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.select :permit_type_id, PermitType.all.collect{|t| [t.name, t.id]} %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :agency %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.select :status, options_for_select(PermitSubmission.statuses.map {|s, v| [s, s] }) %>
+    </div>
+  </div>
+  <div class="flex mb-2 -mx-2">
+    <%= f.label "Deadline", class: "w-1/4 px-2" %>
+    <%= f.label "Permittee", class: "w-1/4 px-2" %>
+    <%= f.label "Equipment", class: "w-1/4 px-2" %>
+    <%= f.label "Location", class: "w-1/4 px-2" %>
+  </div>
+  <div class="flex mb-4 -mx-2">
+    <div class = "w-1/4 px-2">
+      <%= f.date_field :deadline %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :permittee %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :equipment %>
+    </div>
+    <div class = "w-1/4 px-2">
+      <%= f.text_field :location %>
+    </div>
+  </div>
+  <div class="flex">
+    <%= f.fields_for :permit_documents do |document_form| %>
+        <%= document_form.label :document %>
+        <%= document_form.file_field :document %>
+    <% end %>
+  </div>
   <%= submit_tag("Create") %>
 <% end %>

--- a/app/views/permit_submissions/new.html.erb
+++ b/app/views/permit_submissions/new.html.erb
@@ -41,6 +41,19 @@
       <%= f.text_field :location %>
     </div>
   </div>
+  <% if current_user.manager? %>
+		<div class="flex mb-2 -mx-2">
+	    <%= f.label "Assigned User", class: "w-1/4 px-2" %>
+	  </div>
+		<div class="flex mb-4 -mx-2">
+	    <div class = "w-1/4 px-2">
+	      <%= f.select :user_id, User.all.collect{|u| ["#{u.first_name} #{u.last_name}", u.id]} %>
+	    </div>
+	  </div>
+	<% else %>
+		<%= f.hidden_field :user_id, value: current_user.id %>
+		<%= hidden_field_tag 'selected', 'none'  %>
+	<% end %>
   <div class="flex">
     <%= f.fields_for :permit_documents do |document_form| %>
         <%= document_form.label :document %>

--- a/app/views/permit_submissions/new.html.erb
+++ b/app/views/permit_submissions/new.html.erb
@@ -40,15 +40,15 @@
     <div class = "w-1/4 px-2">
       <%= f.text_field :location %>
     </div>
-    <div class="flex mb-2 -mx-2">
-      <%= f.label "Tags", class: "w-1/4 px-2" %>
-  	</div>
-  	<div class="flex mb-4 -mx-2">
-      <div class = "w-1/4 px-2">
-  			<%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>
-      </div>
-  	</div>
   </div>
+  <div class="flex mb-2 -mx-2">
+    <%= f.label "Tags", class: "w-1/4 px-2" %>
+  </div>
+  <div class="flex mb-4 -mx-2">
+    <div class = "w-1/4 px-2">
+			<%= f.text_field :tag_list, value: f.object.tag_list.join(",") %>
+    </div>
+	</div>
   <% if current_user.manager? %>
 		<div class="flex mb-2 -mx-2">
 	    <%= f.label "Assigned User", class: "w-1/4 px-2" %>

--- a/app/views/shared/_permit_row.html.erb
+++ b/app/views/shared/_permit_row.html.erb
@@ -1,4 +1,8 @@
-<div class="Table-cell"><%= permit.name %></div>
+<div class="Table-cell"><%= link_to permit.name, permit_submission_path(id: permit.id) %></div>
 <div class="Table-cell"><%= permit.agency %></div>
 <div class="Table-cell"><%= permit.permit_type.name %></div>
 <div class="Table-cell"><%= permit.deadline.to_date %></div>
+<div class="Table-cell"><%= permit.status %></div>
+<div class="Table-cell"><%= permit.permittee %></div>
+<div class="Table-cell"><%= permit.equipment %></div>
+<div class="Table-cell"><%= permit.location %></div>

--- a/app/views/shared/_show_permit.html.erb
+++ b/app/views/shared/_show_permit.html.erb
@@ -13,7 +13,7 @@
     <%= @permit.agency %>
   </div>
   <div class = "w-1/4 px-2">
-    <%= @permit.status %>
+    <%= PermitSubmission.statuses[@permit.status].humanize %>
   </div>
   <div class = "w-1/4 px-2">
     <%= @permit.deadline %>

--- a/app/views/shared/_show_permit.html.erb
+++ b/app/views/shared/_show_permit.html.erb
@@ -23,7 +23,7 @@
   <div class = "w-1/4 px-2"><b>Permittee</b><br></div>
   <div class = "w-1/4 px-2"><b>Equipment</b><br></div>
   <div class = "w-1/4 px-2"><b>Location</b><br></div>
-  <div class = "w-1/4 px-2"></div>
+  <div class = "w-1/4 px-2"><b>Tags</b><br></div>
 </div>
 <div class="flex mb-4 -mx-2">
   <div class = "w-1/4 px-2">
@@ -35,7 +35,9 @@
   <div class = "w-1/4 px-2">
     <%= @permit.location %>
   </div>
-  <div class = "w-1/4 px-2"></div>
+  <div class = "w-1/4 px-2">
+    <%= @permit.tag_list %>
+  </div>
 </div>
 <div class = "flex mb-4">
   <div class = "w-full">

--- a/app/views/shared/_show_permit.html.erb
+++ b/app/views/shared/_show_permit.html.erb
@@ -1,23 +1,41 @@
-<h1>Permit</h1>
-<div class="flex">
-  <div class = "w-1/4">
-    <b>Name</b><br>
-    <%= @permit.name %>
+<h1 class="mb-2"><%= @permit.name %></h1>
+<div class="flex mb-1 -mx-2">
+  <div class = "w-1/4 px-2"><b>Type</b><br></div>
+  <div class = "w-1/4 px-2"><b>Agency</b><br></div>
+  <div class = "w-1/4 px-2"><b>Status</b><br></div>
+  <div class = "w-1/4 px-2"><b>Deadline</b><br></div>
+</div>
+<div class="flex mb-4 -mx-2">
+  <div class = "w-1/4 px-2">
+    <%= @permit.permit_type.name %>
   </div>
-  <div class = "w-1/4">
-    <b>Agency</b><br>
+  <div class = "w-1/4 px-2">
     <%= @permit.agency %>
   </div>
-  <div class = "w-1/4">
-    <b>Deadline</b><br>
-    <%= @permit.deadline %>
-  </div>
-  <div class = "w-1/4">
-    <b>Status</b><br>
+  <div class = "w-1/4 px-2">
     <%= @permit.status %>
   </div>
+  <div class = "w-1/4 px-2">
+    <%= @permit.deadline %>
+  </div>
 </div>
-<div class = "flex">
+<div class="flex mb-1 -mx-2">
+  <div class = "w-1/4 px-2"><b>Permittee</b><br></div>
+  <div class = "w-1/4 px-2"><b>Equipment</b><br></div>
+  <div class = "w-1/4 px-2"><b>Location</b><br></div>
+</div>
+<div class="flex mb-4 -mx-2">
+  <div class = "w-1/4 px-2">
+    <%= @permit.permittee %>
+  </div>
+  <div class = "w-1/4 px-2">
+    <%= @permit.equipment %>
+  </div>
+  <div class = "w-1/4 px-2">
+    <%= @permit.location %>
+  </div>
+</div>
+<div class = "flex mb-4">
   <div class = "w-full">
     <b>Documents:</b><br>
     <% @permit.permit_documents.map(&:document).map do |document| %>
@@ -25,4 +43,4 @@
     <% end %>
   </div>
 </div>
-<%= link_to 'Back to all permits', permits_path, class: "block p-2" %>
+<%= link_to 'Back to all permits', permits_path, class: "block" %>

--- a/app/views/shared/_show_permit.html.erb
+++ b/app/views/shared/_show_permit.html.erb
@@ -13,7 +13,7 @@
     <%= @permit.agency %>
   </div>
   <div class = "w-1/4 px-2">
-    <%= PermitSubmission.statuses[@permit.status].humanize %>
+    <%= PermitSubmission.statuses[@permit.status].humanize if @permit.status %>
   </div>
   <div class = "w-1/4 px-2">
     <%= @permit.deadline %>
@@ -23,6 +23,7 @@
   <div class = "w-1/4 px-2"><b>Permittee</b><br></div>
   <div class = "w-1/4 px-2"><b>Equipment</b><br></div>
   <div class = "w-1/4 px-2"><b>Location</b><br></div>
+  <div class = "w-1/4 px-2"></div>
 </div>
 <div class="flex mb-4 -mx-2">
   <div class = "w-1/4 px-2">
@@ -34,6 +35,7 @@
   <div class = "w-1/4 px-2">
     <%= @permit.location %>
   </div>
+  <div class = "w-1/4 px-2"></div>
 </div>
 <div class = "flex mb-4">
   <div class = "w-full">

--- a/db/migrate/20200819013323_add_fields_to_permit_submissions.rb
+++ b/db/migrate/20200819013323_add_fields_to_permit_submissions.rb
@@ -1,0 +1,8 @@
+class AddFieldsToPermitSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    change_column :permit_submissions, :status, :integer,  using: 'status::integer'
+    add_column :permit_submissions, :permittee, :text
+    add_column :permit_submissions, :equipment, :text
+    add_column :permit_submissions, :location, :text
+  end
+end

--- a/db/migrate/20200819210758_change_status_on_permit_submissions.rb
+++ b/db/migrate/20200819210758_change_status_on_permit_submissions.rb
@@ -1,0 +1,5 @@
+class ChangeStatusOnPermitSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    change_column :permit_submissions, :status, :string
+  end
+end

--- a/db/migrate/20200825212246_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200825212246_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20200825212247_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200825212247_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200825212248_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200825212248_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20200825212249_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200825212249_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200825212250_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200825212250_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20200825212251_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200825212251_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_175533) do
+ActiveRecord::Schema.define(version: 2020_08_19_013323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -67,11 +67,14 @@ ActiveRecord::Schema.define(version: 2020_07_23_175533) do
     t.string "name"
     t.string "agency"
     t.date "deadline"
-    t.string "status"
+    t.integer "status"
     t.uuid "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "permit_type_id", null: false
+    t.text "permittee"
+    t.text "equipment"
+    t.text "location"
     t.index ["user_id"], name: "index_permit_submissions_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_013323) do
+ActiveRecord::Schema.define(version: 2020_08_19_210758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_013323) do
     t.string "name"
     t.string "agency"
     t.date "deadline"
-    t.integer "status"
+    t.string "status"
     t.uuid "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_210758) do
+ActiveRecord::Schema.define(version: 2020_08_25_212251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -82,6 +82,33 @@ ActiveRecord::Schema.define(version: 2020_08_19_210758) do
     t.string "name"
   end
 
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
@@ -92,4 +119,5 @@ ActiveRecord::Schema.define(version: 2020_08_19_210758) do
 #   Unknown type 'role' for column 'role'
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "taggings", "tags"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,20 +19,29 @@ user.permit_submissions.create!([
     agency: 'NY Department of Motor Vehicles',
     status: 'closed',
     deadline: Date.today,
-    permit_type_id: waste_permit_type.id
+    permit_type_id: waste_permit_type.id,
+    permittee: 'Test Permittee',
+    equipment: 'Equipment',
+    location: 'United States'
 },
   {
     name: 'Air pollution permit',
     agency: 'New York Battery Park City Authority',
     status: 'in-effect',
     deadline: Date.today,
-    permit_type_id: waste_permit_type.id
+    permit_type_id: waste_permit_type.id,
+    permittee: 'Test Permittee',
+    equipment: 'Equipment',
+    location: 'United States'
 },
     {
     name: 'Special truck pollution license',
     agency: 'NY Department of Motor Vehicles',
     status: 'application',
     deadline: Date.today,
-    permit_type_id: waste_permit_type.id
+    permit_type_id: waste_permit_type.id,
+    permittee: 'Test Permittee',
+    equipment: 'Equipment',
+    location: 'United States'
 }
 ])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,21 +17,21 @@ user.permit_submissions.create!([
   {
     name: 'Trade Waste Removal License',
     agency: 'NY Department of Motor Vehicles',
-    status: 0,
+    status: 'closed',
     deadline: Date.today,
     permit_type_id: waste_permit_type.id
 },
   {
     name: 'Air pollution permit',
     agency: 'New York Battery Park City Authority',
-    status: 1,
+    status: 'in-effect',
     deadline: Date.today,
     permit_type_id: waste_permit_type.id
 },
     {
     name: 'Special truck pollution license',
     agency: 'NY Department of Motor Vehicles',
-    status: 2,
+    status: 'application',
     deadline: Date.today,
     permit_type_id: waste_permit_type.id
 }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 
 team = Team.create(name: "Main St. Cafe")
 
-PermitType.create([{ name: "Traffic Permit" }, { name: "Waste Permit" }])
+PermitType.create([{ name: "Traffic Permit" }, { name: "Waste Permit" }, { name: "NYDoH Food" }])
 admin_attributes = { first_name: 'Jane', last_name: 'Doe', team_id: team.id, role: 'manager', email: 'admin@example.com', password: 'abc123' }
 admin_user = User.find_by(admin_attributes.slice(:email))
 User.create!(admin_attributes) unless admin_user.present?
@@ -17,21 +17,21 @@ user.permit_submissions.create!([
   {
     name: 'Trade Waste Removal License',
     agency: 'NY Department of Motor Vehicles',
-    status: 'filed',
+    status: 0,
     deadline: Date.today,
     permit_type_id: waste_permit_type.id
 },
   {
     name: 'Air pollution permit',
     agency: 'New York Battery Park City Authority',
-    status: 'denied',
+    status: 1,
     deadline: Date.today,
     permit_type_id: waste_permit_type.id
 },
     {
     name: 'Special truck pollution license',
     agency: 'NY Department of Motor Vehicles',
-    status: 'accepted',
+    status: 2,
     deadline: Date.today,
     permit_type_id: waste_permit_type.id
 }


### PR DESCRIPTION
Ariel,

This PR addresses both the 'specific permit attributes' and 'adding an assigned user to a permit' cards on Asana. It breaks down into three main parts:

1. Allowing admins to assign permits to certain users, both upon creation and while editing records. Any member of the admins team can be assigned to a permit submission. Regular users do not have the ability to do this.

2. A variety of attributes like 'equipment,' 'permittee,' and 'location' have been added to permit submissions. New, edit, show, and index templates have been updated to reflect these changes. Additionally, due to space issues I removed the "show documents" link and instead have it where you click the name of the permit submission in the larger table to see additional details and documents. I can change this back if need be!

3. The tagging system. I used a gem called 'acts_as_taggable_on' that allows for a basic, comma-separated tagging system on models. I opted to go with this for now, as a more visually-appealing and complex tagging system is going to be a bit more work-intensive than I initially thought. I'm more than happy to get that done if we decide we want to go that route!

Let me know if I can answer any questions or make any adjustments! 